### PR TITLE
Fix invalid capitalization

### DIFF
--- a/splittype.js
+++ b/splittype.js
@@ -667,7 +667,7 @@
       this.chars = [];
 
       // cache vertical scroll position before splitting
-      var scrollPos = [ window.pageXoffset, window.pageYoffset ];
+      var scrollPos = [ window.pageXOffset, window.pageYOffset ];
 
       // If new options were passed into the split() method, update settings for the instance.
       if ( newOptions !== undefined ) {


### PR DESCRIPTION
Using pageXoffset and pageYoffset (with the o not capitalized) returned undefined (at least on Chrome) so it constantly scrolls to the top. Can this be merged and a new version being tagged on NPM?