### PR TITLE
fix: pageXOffset and pageYOffset should be camel case

### DIFF
--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -77,7 +77,7 @@ export default class SplitType {
     this.chars = []
 
     // cache vertical scroll position before splitting
-    const scrollPos = [window.pageXoffset, window.pageYoffset]
+    const scrollPos = [window.pageXOffset, window.pageYOffset]
 
     // If new options were passed into the `split()` method, update settings
     if (options !== undefined) {


### PR DESCRIPTION
The pageXOffset and pageYOffset variables are misspelled causing the page to jump on resize