### PR TITLE
Improve type definitions for split types option

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,10 @@
 declare module 'split-type' {
+  type TypesValue = 'lines' | 'words' | 'chars'
+  type TypesListString =
+    | TypesValue
+    | `${TypesValue}, ${TypesValue}`
+    | `${TypesValue}, ${TypesValue}, ${TypesValue}`
+
   type SplitTypeOptions = {
     absolute: boolean
     tagName: string
@@ -6,8 +12,8 @@ declare module 'split-type' {
     wordClass: string
     charClass: string
     splitClass: string
-    types: string
-    split: string
+    types: TypesListString | TypesValue[]
+    split: TypesListString | TypesValue[]
   }
 
   type TargetElement =


### PR DESCRIPTION
Improves type definitions for the split `types` options.  The value can be a comma separated list of supported "types", or an array of supported types. It now provides autocomplete suggestions for both cases. 

Thanks to @StevenJPx2 for the contribution. Let me know if you have any thoughts before i merge this. 

```js
new SplitType('p', { types: 'lines, words, chars' })
```

```js
new SplitType('p', { types: ['lines', 'words', 'chars'] })
```

https://user-images.githubusercontent.com/8286271/166168960-ea57ad69-f720-464d-8884-3eea7436c39f.mov

closes #22 
