### PR TITLE
fix: absolute position issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,19 +135,29 @@ Caveat: this feature is not compatible with splitting text into lines. When spli
 
 **Absolute vs Relative position**
 
-By default, split text nodes are set to relative position and `display:inline-block`. This allows split text to reflow naturally if the container is resized.
+By default, split text nodes are set to relative position and `display:inline-block`. SplitType also supports absolute position for split text nodes by setting `{ absolute: true }`. When this is enabled, each line/word/character will be set to absolute position, which can improve performance for some animations.
 
-SplitType also supports absolute position for split text nodes by setting `{absolute: true}`. When this is enabled, each line/word/character will be set to absolute position, which can improve performance for some animations. However, split text will not automatically reflow if the container size changes. You will need to manually reposition text after the container is resized.
+**Responsive Text**
+
+When text is split into words and characters using relative position, the text will automatically reflow when the container is resized. However, when absolute position is enabled, or text is split into lines, text will need to re-split after the container is resized. This can be accomplished using event listener or `ResizeObserver`, and calling the `split` method once the window or container element has been resized.
+
+For a complete example, see `__stories__/components/Example.svelte`
 
 ```js
-// Splits text using absolute position for split text elements
-const text = new SplitType('#target', { absolute: true })
+const text = new SplitType('#target')
 
-// Repositions text after the container is resized.
-// Uses lodash#debounce so the split method is only called once after container
-// has been resized.
-const ro = new ResizeObserver(debounce(() => text.split(), 400))
-ro.observe(containerElement)
+// Reposition text after the container is resized (simplified version)
+// This example uses lodash#debounce to ensure the split method only
+// gets called once after the resize is complete.
+const resizeObserver = new ResizeObserver(
+  debounce(([entry]) => {
+    // Note: you should add additional logic so the `split` method is only
+    // called if `entry.contentBoxSize.inlineSize` (the width of the container
+    // element) has changed.
+    text.split()
+  }, 500)
+)
+ro.observe(resizeObserver)
 ```
 
 ## API Reference

--- a/__stories__/03-absolute-position.stories.js
+++ b/__stories__/03-absolute-position.stories.js
@@ -17,12 +17,12 @@ export default {
 const Template = getTemplate({ children })
 
 export const NotSplit = Template.bind({})
-NotSplit.args = { types: 'none', position: 'absolute' }
+NotSplit.args = { types: 'none', absolute: true }
 
 export const SplitLinesWordsAndChars = Template.bind({})
 SplitLinesWordsAndChars.args = {
   types: 'lines, words, chars',
-  position: 'absolute',
+  absolute: true,
 }
 SplitLinesWordsAndChars.parameters = {
   async puppeteerTest(page) {
@@ -33,7 +33,7 @@ SplitLinesWordsAndChars.parameters = {
 }
 
 export const SplitLinesAndWords = Template.bind({})
-SplitLinesAndWords.args = { types: 'lines, words', position: 'absolute' }
+SplitLinesAndWords.args = { types: 'lines, words', absolute: true }
 SplitLinesAndWords.parameters = {
   async puppeteerTest(page) {
     expect((await page.$$('.target > .line')).length).toEqual(lineCount)
@@ -43,7 +43,7 @@ SplitLinesAndWords.parameters = {
 }
 
 export const SplitWordsAndChars = Template.bind({})
-SplitWordsAndChars.args = { types: 'words, chars', position: 'absolute' }
+SplitWordsAndChars.args = { types: 'words, chars', absolute: true }
 SplitWordsAndChars.parameters = {
   async puppeteerTest(page) {
     expect((await page.$$('.line')).length).toEqual(0)
@@ -53,7 +53,7 @@ SplitWordsAndChars.parameters = {
 }
 
 export const SplitLines = Template.bind({})
-SplitLines.args = { types: 'lines', position: 'absolute' }
+SplitLines.args = { types: 'lines', absolute: true }
 SplitLines.parameters = {
   async puppeteerTest(page) {
     expect((await page.$$('.target > .line')).length).toEqual(lineCount)
@@ -63,7 +63,7 @@ SplitLines.parameters = {
 }
 
 export const SplitWords = Template.bind({})
-SplitWords.args = { types: 'words', position: 'absolute' }
+SplitWords.args = { types: 'words', absolute: true }
 SplitWords.parameters = {
   async puppeteerTest(page) {
     expect((await page.$$('.line')).length).toEqual(0)

--- a/__stories__/05-nested-elements-absolute.stories.js
+++ b/__stories__/05-nested-elements-absolute.stories.js
@@ -30,7 +30,7 @@ NotSplit.args = { types: 'none' }
 export const SplitLinesWordsAndChars = Template.bind({})
 SplitLinesWordsAndChars.args = {
   types: 'lines, words, chars',
-  position: 'absolute',
+  absolute: true,
 }
 SplitLinesWordsAndChars.parameters = {
   async puppeteerTest(page) {
@@ -63,7 +63,7 @@ SplitLinesWordsAndChars.parameters = {
 }
 
 export const SplitLinesAndWords = Template.bind({})
-SplitLinesAndWords.args = { types: 'lines, words', position: 'absolute' }
+SplitLinesAndWords.args = { types: 'lines, words', absolute: true }
 SplitLinesAndWords.parameters = {
   async puppeteerTest(page) {
     // Total number of line, word, and character elements is correct
@@ -96,7 +96,7 @@ SplitLinesAndWords.parameters = {
 }
 
 export const SplitWordsAndChars = Template.bind({})
-SplitWordsAndChars.args = { types: 'words, chars', position: 'absolute' }
+SplitWordsAndChars.args = { types: 'words, chars', absolute: true }
 SplitWordsAndChars.parameters = {
   async puppeteerTest(page) {
     // Total number of line, word, and character elements is correct
@@ -126,7 +126,7 @@ SplitWordsAndChars.parameters = {
 }
 
 export const SplitWords = Template.bind({})
-SplitWords.args = { types: 'words', position: 'absolute' }
+SplitWords.args = { types: 'words', absolute: true }
 SplitWords.parameters = {
   async puppeteerTest(page) {
     // Total number of line, word, and character elements is correct

--- a/__stories__/06-multi-line-nested-elements.stories.js
+++ b/__stories__/06-multi-line-nested-elements.stories.js
@@ -14,7 +14,7 @@ const { words: actualWords, chars, plainWords } = count(children)
 const words = actualWords + 3
 
 // Create the story template
-const Template = getTemplate({ children })
+const Template = getTemplate({ children, className: 'fixed' })
 
 export const NotSplit = Template.bind({})
 NotSplit.args = { types: 'none' }

--- a/__stories__/07-multi-line-nested-elements-absolute.stories.js
+++ b/__stories__/07-multi-line-nested-elements-absolute.stories.js
@@ -23,7 +23,7 @@ async function getSplitTextNodes(page) {
 }
 
 // Create the story template
-const Template = getTemplate({ children })
+const Template = getTemplate({ children, className: 'fixed' })
 
 export const NotSplit = Template.bind({})
 NotSplit.args = { types: 'none' }

--- a/__stories__/assets/styles.css
+++ b/__stories__/assets/styles.css
@@ -24,6 +24,17 @@ body {
   box-sizing: border-box;
 }
 
+.container {
+  margin: 16px;
+  padding: 16px;
+  width: 100%;
+  max-width: 732px;
+}
+
+.container.fixed {
+  width: 732px;
+}
+
 .target {
   flex: 1;
   font-family: Roboto;
@@ -33,7 +44,6 @@ body {
   font-kerning: none;
   font-variant-ligatures: none;
   font-size: var(--fontSize);
-  max-width: 700px;
 }
 
 /* Make sure nested elements have same font size */

--- a/__stories__/components/ResizeObserver.js
+++ b/__stories__/components/ResizeObserver.js
@@ -1,0 +1,7 @@
+function ResizeObserverPolyfill() {
+  this.observe = () => {}
+  this.destroy = () => {}
+}
+
+const SafeResizeObserver = ResizeObserver || ResizeObserverPolyfill
+export default SafeResizeObserver

--- a/__stories__/components/ResizeObserver.js
+++ b/__stories__/components/ResizeObserver.js
@@ -1,7 +1,4 @@
-function ResizeObserverPolyfill() {
+export default function ResizeObserverPolyfill() {
   this.observe = () => {}
   this.destroy = () => {}
 }
-
-const SafeResizeObserver = ResizeObserver || ResizeObserverPolyfill
-export default SafeResizeObserver

--- a/__stories__/helpers/getTemplate.js
+++ b/__stories__/helpers/getTemplate.js
@@ -2,10 +2,10 @@ import Example from '../components/Example.svelte'
 
 export default function getTemplate(defaultArgs) {
   return (args) => {
-    const { children, ...options } = { ...defaultArgs, ...args }
+    const { children, className = '', ...options } = { ...defaultArgs, ...args }
     return {
       Component: Example,
-      props: { children, options },
+      props: { children, className, options },
     }
   }
 }

--- a/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/__tests__/__snapshots__/snapshots.test.js.snap
@@ -154,9 +154,6 @@ SplitType {
       </div>
     </div>,
   ],
-  "originals": Array [
-    "Foo Bar",
-  ],
   "settings": Object {
     "absolute": false,
     "charClass": "char",
@@ -249,9 +246,6 @@ SplitType {
        
       Bar
     </div>,
-  ],
-  "originals": Array [
-    "Foo Bar",
   ],
   "settings": Object {
     "absolute": false,
@@ -364,9 +358,6 @@ SplitType {
   ],
   "isSplit": true,
   "lines": Array [],
-  "originals": Array [
-    "Foo Bar",
-  ],
   "settings": Object {
     "absolute": false,
     "charClass": "char",
@@ -526,9 +517,6 @@ SplitType {
   ],
   "isSplit": true,
   "lines": Array [],
-  "originals": Array [
-    "Foo Bar",
-  ],
   "settings": Object {
     "absolute": false,
     "charClass": "char",

--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -102,7 +102,6 @@ export default class SplitType {
     this.elements.forEach((element) => {
       // Store original html content of each target element
       Data(element).html = element.innerHTML
-      Data(element).inlineStyles = element.getAttribute('style')
     })
     this.split()
   }
@@ -180,10 +179,11 @@ export default class SplitType {
     // Note: this will revert the target elements even if they were split by a
     // different splitType instance.
     this.elements.forEach((element) => {
-      const { isSplit, html, inlineStyle = '' } = Data(element)
+      const { isSplit, html, cssWidth, cssHeight } = Data(element)
       if (isSplit) {
         element.innerHTML = html
-        element.setAttribute('style', inlineStyle)
+        element.style.width = cssWidth || ''
+        element.style.height = cssHeight || ''
         Data(element).isSplit = false
       }
     })

--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -49,6 +49,23 @@ export default class SplitType {
   }
 
   /**
+   * A static method to revert the target elements.
+   * This provides a way to revert elements without having a reference to the
+   * SplitType instance.
+   */
+  static revert(target) {
+    const elements = getTargetElements(target)
+    elements.forEach((element) => {
+      const { isSplit, html } = Data(element)
+      if (isSplit) {
+        element.innerHTML = html || ''
+        Data(element).isSplit = false
+        Data(element).html = null
+      }
+    })
+  }
+
+  /**
    * Creates a new SplitType instance with the given parameters
    * This static method provides a way to create a splitType instance without
    * using the new keyword.
@@ -80,16 +97,14 @@ export default class SplitType {
     this.settings = extend(_defaults, parseSettings(options))
     this.elements = getTargetElements(target) || []
 
-    if (this.elements.length) {
-      // Store the original HTML content of each target element
-      this.originals = this.elements.map((element) =>
-        Data(element, 'html', Data(element).html || element.innerHTML)
-      )
-      if (this.settings.types) {
-        // Initiate the split operation.
-        this.split()
-      }
-    }
+    this.revert()
+
+    this.elements.forEach((element) => {
+      // Store original html content of each target element
+      Data(element).html = element.innerHTML
+      Data(element).inlineStyles = element.getAttribute('style')
+    })
+    this.split()
   }
 
   /**
@@ -100,8 +115,7 @@ export default class SplitType {
    * @public
    */
   split(options) {
-    // If any of the target elements have already been split,
-    // revert them back to their original content before splitting them.
+    // Revert elements if they are already split
     this.revert()
 
     // Create arrays to hold the split lines, words, and characters
@@ -120,18 +134,24 @@ export default class SplitType {
 
     // If the `types` option is set to an empty array, text will not be split.
     // @example new SplitType('#target', { types: [] })
-    if (types.none) return
+    if (types.none) {
+      return
+    }
 
     // Split text in each target element
     this.elements.forEach((element) => {
       // Add the split text nodes from this element to the arrays of all split
       // text nodes for this instance.
       Data(element).isRoot = true
+      // const copy = element.cloneNode(true)
       const { words, chars } = split(element, this.settings)
       this.words = [...this.words, ...words]
       this.chars = [...this.chars, ...chars]
+    })
+
+    this.elements.forEach((element) => {
       if (types.lines || this.settings.absolute) {
-        const lines = repositionAfterSplit(element, this.settings)
+        const lines = repositionAfterSplit(element, this.settings, scrollPos)
         this.lines = [...this.lines, ...lines]
       }
     })
@@ -142,10 +162,12 @@ export default class SplitType {
     // Set scroll position to cached value.
     window.scrollTo(scrollPos[0], scrollPos[1])
 
-    // Clear data Cache
+    // Clear data cache
     this.elements.forEach((element) => {
-      const nodes = Data(element).nodes || []
-      toArray(nodes).forEach(RemoveData)
+      // Deletes cached data for nodes within the target element.
+      // Does not remove data stored on the target element itself.
+      toArray(Data(element).nodes).forEach(RemoveData)
+      Data(element).nodes = null
     })
   }
 
@@ -154,21 +176,24 @@ export default class SplitType {
    * @public
    */
   revert() {
-    // Delete the arrays of split text elements
+    // restore original HTML content
+    // Note: this will revert the target elements even if they were split by a
+    // different splitType instance.
+    this.elements.forEach((element) => {
+      const { isSplit, html, inlineStyle = '' } = Data(element)
+      if (isSplit) {
+        element.innerHTML = html
+        element.setAttribute('style', inlineStyle)
+        Data(element).isSplit = false
+      }
+    })
+
+    // Reset instance properties if necessary
     if (this.isSplit) {
       this.lines = null
       this.words = null
       this.chars = null
+      this.isSplit = false
     }
-
-    // Remove split text from target elements and restore original content
-    this.elements.forEach((element) => {
-      if (Data(element).isSplit && Data(element).html) {
-        element.innerHTML = Data(element).html
-        element.style.height = Data(element).cssHeight || ''
-        element.style.width = Data(element).cssWidth || ''
-        this.isSplit = false
-      }
-    })
   }
 }

--- a/lib/repositionAfterSplit.js
+++ b/lib/repositionAfterSplit.js
@@ -1,13 +1,13 @@
 import toArray from './utils/toArray'
 import parseTypes from './utils/parseTypes'
-import createTextNode from './utils/createTextNode'
+import getPosition from './utils/getPosition'
 import createElement from './utils/createElement'
 import unSplitWords from './unSplitWords'
 import { Data } from './Data'
 
 const createFragment = () => document.createDocumentFragment()
 
-export default function repositionAfterSplit(element, settings) {
+export default function repositionAfterSplit(element, settings, scrollPos) {
   const types = parseTypes(settings.types)
   const TAG_NAME = settings.tagName
   const nodes = element.getElementsByTagName('*')
@@ -18,6 +18,10 @@ export default function repositionAfterSplit(element, settings) {
   let elementWidth
   let contentBox
   let lines = []
+
+  // We store the nodeList temporarily so we can clear all stored data for these
+  // nodes once the split operation is complete.
+  Data(element).nodes = nodes
 
   /**------------------------------------------------
    ** GET STYLES AND POSITIONS
@@ -73,23 +77,22 @@ export default function repositionAfterSplit(element, settings) {
   toArray(nodes).forEach((node) => {
     // node is a word element or custom html element
     const isWordLike = node.parentElement === element
-    let wordOffsetY
-
+    // TODO needs work
+    const { width, height, top, left } = getPosition(
+      node,
+      isWordLike,
+      settings,
+      scrollPos
+    )
     // If element is a `<br>` tag return here
     if (/^br$/i.test(node.nodeName)) return
 
     if (types.lines && isWordLike) {
-      // If Splitting text into lines
-      // Detect line breaks by checking the top offset of word element
-      // wordOffsetY is the top offset of the current word or element
-      wordOffsetY = node.offsetTop
-      Data(node).top = wordOffsetY
-
       // We compare the top offset of the current word to the top offset of
       // previous words on the current line. If the difference is greater than
       // our defined threshold (20%), we assume this word is on a new line.
-      if (lineOffsetY === null || wordOffsetY - lineOffsetY >= lineThreshold) {
-        lineOffsetY = wordOffsetY
+      if (lineOffsetY === null || top - lineOffsetY >= lineThreshold) {
+        lineOffsetY = top
         wordsInEachLine.push((wordsInCurrentLine = []))
       }
 
@@ -103,10 +106,10 @@ export default function repositionAfterSplit(element, settings) {
       // All split nodes have the same height (lineHeight). So its only
       // retrieved once.
       // If offset top has already been cached (step 11 a) use the stored value.
-      Data(node).top = wordOffsetY || node.offsetTop
-      Data(node).left = node.offsetLeft
-      Data(node).width = node.offsetWidth
-      Data(node).height = node.offsetHeight
+      Data(node).top = top
+      Data(node).left = left
+      Data(node).width = width
+      Data(node).height = height
     }
   }) // END LOOP
 
@@ -142,18 +145,19 @@ export default function repositionAfterSplit(element, settings) {
         const { isWordEnd, top, height } = Data(wordOrElement)
         const next = arr[idx + 1]
 
-        // Determine line height / position...
-        // The height and position of each line is determined by the height
-        // and position of the word elements on that line. Due to support for
-        // nested elements which can have their own styles, all words may not
-        // be the same height. We use the height/offsetTop of the largest word
-        // element on each line.
+        // Determine line height / y-position
+        // we use the height and offsetTop of the words which we already
+        // recorded. Because custom nested elements could have their own
+        // styles, the words on a line may not all be the same height or
+        // y position. So we take the greatest height / y - offset of the
+        // words on this line.
         lineDimensions.height = Math.max(lineDimensions.height, height)
-        lineDimensions.top = Math.max(lineDimensions.top, top)
-
+        lineDimensions.top = Math.min(lineDimensions.top, top)
+        // append the current word/element
         lineElement.appendChild(wordOrElement)
         // Determine if there should space after the current element...
-        // If this is not the last word on the current line
+        // If this is not the last word on the current line.
+        // TODO - logic for handing spacing can be improved
         if (isWordEnd && Data(next).isWordStart) {
           lineElement.append(' ')
         }

--- a/lib/repositionAfterSplit.js
+++ b/lib/repositionAfterSplit.js
@@ -69,6 +69,7 @@ export default function repositionAfterSplit(element, settings, scrollPos) {
     elementWidth = element.offsetWidth
     elementHeight = element.offsetHeight
 
+    // Store the original inline height and width of the element
     Data(element).cssWidth = element.style.width
     Data(element).cssHeight = element.style.height
   }

--- a/lib/split.js
+++ b/lib/split.js
@@ -3,44 +3,48 @@ import splitWordsAndChars from './splitWordsAndChars'
 import { Data } from './Data'
 
 /**
+ * Splits the text content of a target element into words and/or characters.
+ * The function is recursive, it will also split the text content of any child
+ * elements into words/characters, while preserving the nested elements.
+ *
  * @param {Node} element an HTML Element or Text Node
  * @param {Object} setting splitType settings
  */
 export default function split(element, settings) {
-  // -> A) If `element` is a text node...
+  // A) If `element` is a text node...
   //    Split the text content of the node into words and/or characters
   //    returns an object containing the split word and characters
   if (element.nodeType === 3) {
     return splitWordsAndChars(element, settings)
   }
 
-  // -> B) if not, element is an HTML element or fragment
+  // B) if not, element is an HTML element or fragment
   //    We will iterate through the child nodes of the element,
   //    calling the `split` function recursively for each child.
   const childNodes = toArray(element.childNodes)
 
   if (childNodes.length) {
     Data(element).isSplit = true
-    // we need to set a few styles on custom html elements inside
-    // the root element.
+    // we need to set a few styles on nested html elements
     if (!Data(element).isRoot) {
       element.style.display = 'inline-block'
       element.style.position = 'relative'
-      // To maintain original white space around nested elements when we are
+      // To maintain original spacing around nested elements when we are
       // splitting text into lines, we need to check if the element should
       // have a space before and after, and store that value for later.
-      // TODO: find a better way to do this
+      // Note: this was necessary to maintain the correct spacing when nested
+      // elements do not align with word boundaries. For example, a nested
+      // element only wraps part of a word.
       const nextSibling = element.nextSibling
       const prevSibling = element.previousSibling
       const text = element.textContent || ''
-      const textAfter = (nextSibling && nextSibling.textContent) || ''
-      const textBefore = (prevSibling && prevSibling.textContent) || ''
+      const textAfter = nextSibling ? nextSibling.textContent : ' '
+      const textBefore = prevSibling ? prevSibling.textContent : ' '
       Data(element).isWordEnd = /\s$/.test(text) || /^\s/.test(textAfter)
       Data(element).isWordStart = /^\s/.test(text) || /\s$/.test(textBefore)
     }
   }
 
-  // An object containing arrays of all split words / chars
   const wordsAndChars = { words: [], chars: [] }
 
   // Iterate through child nodes, calling `split` recursively

--- a/lib/splitWordsAndChars.js
+++ b/lib/splitWordsAndChars.js
@@ -35,7 +35,7 @@ export default function splitWordsAndChars(textNode, settings) {
   let chars = []
 
   if (/^\s/.test(textNode.nodeValue)) {
-    splitText.append(createTextNode(' '))
+    splitText.append(' ')
   }
 
   // Create an array of wrapped word elements.
@@ -95,7 +95,7 @@ export default function splitWordsAndChars(textNode, settings) {
 
   // Add a trailing white space to maintain word spacing
   if (/\s$/.test(textNode.nodeValue)) {
-    splitText.append(createTextNode(' '))
+    splitText.append(' ')
   }
   textNode.replaceWith(splitText)
   return { words, chars }

--- a/lib/utils/getPosition.js
+++ b/lib/utils/getPosition.js
@@ -1,0 +1,25 @@
+/**
+ * Gets the height and position of an element relative to offset parent.
+ * Should be equivalent to offsetTop and offsetHeight, but with sub-pixel
+ * precision.
+ *
+ * TODO needs work
+ */
+export default function getPosition(node, isWord, settings, scrollPos) {
+  if (!settings.absolute) {
+    return { top: isWord ? node.offsetTop : null }
+  }
+  const parent = node.offsetParent
+  const [scrollX, scrollY] = scrollPos
+  let parentX = 0
+  let parentY = 0
+  if (parent && parent !== document.body) {
+    const parentRect = parent.getBoundingClientRect()
+    parentX = parentRect.x + scrollX
+    parentY = parentRect.y + scrollY
+  }
+  const { width, height, x, y } = node.getBoundingClientRect()
+  const top = y + scrollY - parentY
+  const left = x + scrollX - parentX
+  return { width, height, top, left }
+}


### PR DESCRIPTION
Fixes two issues with absolute position:

1. Text disappear when text is split into lines only, and target
element does not contain any nested elements.

2. Splitting text with absolute position slightly changes the visual
appearance of the text. This was due to the fact that we used
`offsetTop` and `offsetLeft`, which do not have sub-pixel precision.
Now, we use `getBoundingClientRect` to determine the size and
position of split text nodes. This has a slight negative impact on
performance. But it prevents text from visibly shifting when it
is split/un-split.

#### Before

The characters shift around slightly when text is split/un-split

https://user-images.githubusercontent.com/8286271/172066517-d6a7fc1d-3046-425c-9f2d-edf02820134c.mov

#### After

No visible change when text is split/un-split 

https://user-images.githubusercontent.com/8286271/172066524-d1afd0ca-056a-4ebc-ada3-8e7f7f9aa09b.mov


