### PR TITLE
Fix: not working when target element contains comment nodes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,8 +5,9 @@ name: 'Chromatic'
 
 # Event for the workflow
 on:
-  pull_request:
-    branches: [master]
+  push:
+    branches-ignore:
+      - 'gh-pages'
 
 # List of jobs
 jobs:

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,6 +1,8 @@
 // .storybook/manager.js
 
 import { addons } from '@storybook/addons'
+import { themes } from '@storybook/theming'
+import theme from './theme'
 
 addons.setConfig({
   isFullscreen: false,
@@ -10,7 +12,7 @@ addons.setConfig({
   sidebarAnimations: true,
   enableShortcuts: true,
   isToolshown: true,
-  theme: undefined,
+  theme: theme,
   selectedPanel: undefined,
   initialActive: 'sidebar',
   sidebar: {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,3 @@
-<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="prism.css" />
+<link rel="stylesheet" href="stories.css" />
+<link rel="stylesheet" href="docs.css" />

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,1 +1,14 @@
-export const parameters = {}
+import { themes } from '@storybook/theming'
+import theme from './theme'
+
+// or global addParameters
+export const parameters = {
+  docs: {
+    theme: theme,
+  },
+  previewTabs: {
+    'storybook/docs/panel': {
+      hidden: true,
+    },
+  },
+}

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,0 +1,16 @@
+import { create } from '@storybook/theming'
+
+export default create({
+  base: 'light',
+  colorPrimary: '#24292f',
+  colorSecondary: '#0969da',
+  fontCode:
+    'ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace',
+  textColor: '#24292f',
+  barTextColor: '#24292f',
+  barSelectedColor: '#24292f',
+  // brandTitle: 'SplitType',
+  // brandImage: '',
+  // brandUrl: '',
+  // brandTarget: '_self',
+})

--- a/__stories__/01-basic.stories.js
+++ b/__stories__/01-basic.stories.js
@@ -8,11 +8,6 @@ const { words, chars } = count(children)
 export default {
   title: 'Tests/Basic',
   argTypes: { ...baseArgTypes },
-  parameters: {
-    docs: {
-      page: null,
-    },
-  },
 }
 
 const Template = getTemplate({ children })

--- a/__stories__/12-with-html-comments.stories.js
+++ b/__stories__/12-with-html-comments.stories.js
@@ -1,0 +1,91 @@
+import getTemplate from './helpers/getTemplate'
+import { baseArgTypes } from './constants'
+
+const actualText = `Typography is the art and technique of arranging type to make written language legible, readable, and appealing when displayed.`
+
+const children = `
+<!--this is a comment node -->
+<!--this is a comment node -->
+<!--this is a comment node -->
+<!--this is a comment node -->
+${actualText}
+<!--this is a comment node -->
+<!--this is a comment node -->
+<!--this is a comment node -->
+<!--this is a comment node -->
+`
+
+const lineCount = 3
+const wordCount = actualText.split(' ').length
+const charCount = actualText.replace(/\s+/g, '').split('').length
+
+export default {
+  title: 'Tests/With HTML Comments',
+  argTypes: { ...baseArgTypes },
+}
+
+const Template = getTemplate({ children })
+
+export const NotSplit = Template.bind({})
+NotSplit.args = { types: 'none' }
+
+export const SplitLinesWordsAndChars = Template.bind({})
+SplitLinesWordsAndChars.args = { types: 'lines, words, chars' }
+SplitLinesWordsAndChars.parameters = {
+  async puppeteerTest(page) {
+    expect((await page.$$('.target > .line')).length).toEqual(lineCount)
+    expect((await page.$$('.line > .word')).length).toEqual(wordCount)
+    expect((await page.$$('.word > .char')).length).toEqual(charCount)
+  },
+}
+
+export const SplitLinesAndWords = Template.bind({})
+SplitLinesAndWords.args = { types: 'lines, words' }
+SplitLinesAndWords.parameters = {
+  async puppeteerTest(page) {
+    expect((await page.$$('.target > .line')).length).toEqual(lineCount)
+    expect((await page.$$('.line > .word')).length).toEqual(wordCount)
+    expect((await page.$$('.char')).length).toEqual(0)
+  },
+}
+
+export const SplitLinesAndChars = Template.bind({})
+SplitLinesAndChars.args = { types: 'lines, chars', absolute: false }
+SplitLinesAndChars.parameters = {
+  async puppeteerTest(page) {
+    expect((await page.$$('.target > .line')).length).toEqual(lineCount)
+    expect((await page.$$('.line > .char')).length).toEqual(charCount)
+  },
+}
+
+export const SplitWordsAndChars = Template.bind({})
+SplitWordsAndChars.args = { types: 'words, chars' }
+SplitWordsAndChars.parameters = {
+  async puppeteerTest(page) {
+    // Should not contain any line elements
+    expect((await page.$$('.line')).length).toEqual(0)
+    //
+    expect((await page.$$('.target > .word')).length).toEqual(wordCount)
+    expect((await page.$$('.word > .char')).length).toEqual(charCount)
+  },
+}
+
+export const SplitLines = Template.bind({})
+SplitLines.args = { types: 'lines' }
+SplitLines.parameters = {
+  async puppeteerTest(page) {
+    expect((await page.$$('.target > .line')).length).toEqual(lineCount)
+    expect((await page.$$('.word')).length).toEqual(0)
+    expect((await page.$$('.char')).length).toEqual(0)
+  },
+}
+
+export const SplitWords = Template.bind({})
+SplitWords.args = { types: 'words' }
+SplitWords.parameters = {
+  async puppeteerTest(page) {
+    expect((await page.$$('.line')).length).toEqual(0)
+    expect((await page.$$('.target > .word')).length).toEqual(wordCount)
+    expect((await page.$$('.char')).length).toEqual(0)
+  },
+}

--- a/__stories__/12-with-html-comments.stories.js
+++ b/__stories__/12-with-html-comments.stories.js
@@ -1,14 +1,14 @@
 import getTemplate from './helpers/getTemplate'
 import { baseArgTypes } from './constants'
 
-const actualText = `Typography is the art and technique of arranging type to make written language legible, readable, and appealing when displayed.`
+const text = `Typography is the art and technique of arranging type to make written language legible, readable, and appealing when displayed.`
 
 const children = `
 <!--this is a comment node -->
 <!--this is a comment node -->
 <!--this is a comment node -->
 <!--this is a comment node -->
-${actualText}
+${text}
 <!--this is a comment node -->
 <!--this is a comment node -->
 <!--this is a comment node -->
@@ -16,8 +16,8 @@ ${actualText}
 `
 
 const lineCount = 3
-const wordCount = actualText.split(' ').length
-const charCount = actualText.replace(/\s+/g, '').split('').length
+const wordCount = text.split(' ').length
+const charCount = text.replace(/\s+/g, '').split('').length
 
 export default {
   title: 'Tests/With HTML Comments',

--- a/__stories__/assets/docs.css
+++ b/__stories__/assets/docs.css
@@ -1,0 +1,77 @@
+@import 'variables.css';
+
+body {
+  font-size: var(--font-body) !important;
+}
+
+#docs-root .sbdocs {
+  font-size: var(--font-size);
+}
+.sbdocs-content > *:first-child {
+  margin-top: 0 !important;
+}
+
+#docs-root .sbdocs-h1,
+#docs-root .sbdocs-h2,
+#docs-root .sbdocs-h3,
+#docs-root .sbdocs-h4,
+#docs-root .sbdocs-h5,
+#docs-root .sbdocs-h5 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+#docs-root .sbdocs-h1 {
+  padding-bottom: 0.3em;
+  font-size: 2em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+#docs-root .sbdocs-h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+#docs-root .sbdocs-h3 {
+  font-size: 1.25em;
+}
+
+#docs-root .sbdocs-h4 {
+  font-size: 1em;
+}
+
+/* Top level wrapper for documentation pages  */
+#docs-root .sbdocs.sbdocs-wrapper {
+  padding: 2rem 20px;
+}
+
+/* Inline code styles */
+#docs-root code {
+  font-family: var(--font-mono);
+  color: inherit;
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: var(--code-font-size);
+  background-color: var(--color-canvas-subtle);
+  border-radius: 6px;
+  -webkit-font-smoothing: auto !important;
+}
+
+/* Code block container */
+#docs-root .docblock-source {
+  margin-top: 0;
+  margin-bottom: 16px;
+  box-shadow: none;
+  background-color: var(--color-canvas-subtle);
+  border: none;
+  font-size: var(--font-size);
+}
+
+/* Code block  */
+#docs-root pre.prismjs {
+  font-size: var(--code-font-size);
+  -webkit-font-smoothing: auto !important;
+}

--- a/__stories__/assets/prism.css
+++ b/__stories__/assets/prism.css
@@ -1,0 +1,203 @@
+/* PrismJS 1.28.0
+https://prismjs.com/download.html#themes=prism-coy&languages=markup+css+clike+javascript&plugins=highlight-keywords */
+code[class*='language-'],
+pre[class*='language-'] {
+  color: #000;
+  background: 0 0;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 1em;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+pre[class*='language-'] {
+  position: relative;
+  margin: 0.5em 0;
+  overflow: visible;
+  padding: 1px;
+}
+pre[class*='language-'] > code {
+  position: relative;
+  z-index: 1;
+  border-left: 10px solid #358ccb;
+  box-shadow: -1px 0 0 0 #358ccb, 0 0 0 1px #dfdfdf;
+  background-color: #fdfdfd;
+  background-image: linear-gradient(
+    transparent 50%,
+    rgba(69, 142, 209, 0.04) 50%
+  );
+  background-size: 3em 3em;
+  background-origin: content-box;
+  background-attachment: local;
+}
+code[class*='language-'] {
+  max-height: inherit;
+  height: inherit;
+  padding: 0 1em;
+  display: block;
+  overflow: auto;
+}
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  background-color: #fdfdfd;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  margin-bottom: 1em;
+}
+:not(pre) > code[class*='language-'] {
+  position: relative;
+  padding: 0.2em;
+  border-radius: 0.3em;
+  color: #c92c2c;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  display: inline;
+  white-space: normal;
+}
+pre[class*='language-']:after,
+pre[class*='language-']:before {
+  content: '';
+  display: block;
+  position: absolute;
+  bottom: 0.75em;
+  left: 0.18em;
+  width: 40%;
+  height: 20%;
+  max-height: 13em;
+  box-shadow: 0 13px 8px #979797;
+  -webkit-transform: rotate(-2deg);
+  -moz-transform: rotate(-2deg);
+  -ms-transform: rotate(-2deg);
+  -o-transform: rotate(-2deg);
+  transform: rotate(-2deg);
+}
+pre[class*='language-']:after {
+  right: 0.75em;
+  left: auto;
+  -webkit-transform: rotate(2deg);
+  -moz-transform: rotate(2deg);
+  -ms-transform: rotate(2deg);
+  -o-transform: rotate(2deg);
+  transform: rotate(2deg);
+}
+#docs-root .token.block-comment,
+#docs-root .token.cdata,
+#docs-root .token.comment,
+#docs-root .token.doctype,
+#docs-root .token.prolog {
+  font-style: normal;
+  color: #7d8b99;
+}
+#docs-root .token.punctuation {
+  color: #5f6364;
+}
+#docs-root .token.boolean,
+#docs-root .token.constant,
+#docs-root .token.deleted,
+#docs-root .token.function-name,
+#docs-root .token.number,
+#docs-root .token.symbol {
+  color: #c92c2c;
+}
+
+#docs-root .token.builtin,
+#docs-root .token.char,
+#docs-root .token.inserted,
+#docs-root .token.selector,
+#docs-root .token.string,
+#docs-root .token.tag.attr-value,
+#docs-root .token.regex,
+#docs-root .token.important {
+  color: #0a3069;
+}
+
+#docs-root .token.entity,
+#docs-root .token.url {
+  color: #a67f59;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+#docs-root .token.variable,
+#docs-root .token.class-name {
+  color: #953800;
+}
+
+#docs-root .token.tag {
+  color: #116329;
+}
+#docs-root .token.atrule,
+#docs-root .token.attr-value,
+#docs-root .token.keyword,
+#docs-root .token.operator {
+  color: #cf222e;
+}
+#docs-root .token.module #docs-root .token.method,
+#docs-root .token.property-access,
+#docs-root .token.function {
+  color: #8250df;
+}
+
+#docs-root .token.attr-name,
+#docs-root .token.number,
+#docs-root .token.property {
+  color: #0550ae;
+}
+
+#docs-root .language-css .token.string,
+#docs-root .style .token.string {
+  color: #a67f59;
+  background: rgba(255, 255, 255, 0.5);
+}
+#docs-root .token.important {
+  font-weight: 400;
+}
+#docs-root .token.bold {
+  font-weight: 700;
+}
+#docs-root .token.italic {
+  font-style: italic;
+}
+#docs-root .token.entity {
+  cursor: help;
+}
+#docs-root .token.namespace {
+  opacity: 0.7;
+}
+@media screen and (max-width: 767px) {
+  pre[class*='language-']:after,
+  pre[class*='language-']:before {
+    bottom: 14px;
+    box-shadow: none;
+  }
+}
+pre[class*='language-'].line-numbers.line-numbers {
+  padding-left: 0;
+}
+pre[class*='language-'].line-numbers.line-numbers code {
+  padding-left: 3.8em;
+}
+pre[class*='language-'].line-numbers.line-numbers .line-numbers-rows {
+  left: 0;
+}
+pre[class*='language-'][data-line] {
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+}
+pre[data-line] code {
+  position: relative;
+  padding-left: 4em;
+}
+pre .line-highlight {
+  margin-top: 0;
+}

--- a/__stories__/assets/stories.css
+++ b/__stories__/assets/stories.css
@@ -1,11 +1,6 @@
+@import 'variables.css';
 :root {
-  --text: #333;
-  --code: #787282;
-  --accent: #fb7a7a;
-  --primary: #1ea7fd;
-  --primaryDark: #077cc5;
-  --primaryLight: #3bb4ff;
-  --fontSize: 32px;
+  --example-font-size: 32px;
 }
 
 body {
@@ -13,6 +8,9 @@ body {
   padding: 0 !important;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  font-size: var(--font-size);
+  line-height: 1.5;
+  color: var(--color-default-fg);
 }
 
 .container {
@@ -38,12 +36,12 @@ body {
 }
 
 .target {
-  color: var(--text);
+  color: var(--color-default-fg);
   line-height: 1.5;
   letter-spacing: normal;
   font-kerning: none;
   font-variant-ligatures: none;
-  font-size: var(--fontSize);
+  font-size: var(--example-font-size);
 }
 
 /* Make sure nested elements have same font size */
@@ -67,13 +65,13 @@ Buttons and Links
 }
 
 .target a {
-  color: var(--primary);
+  color: var(--color-accent-fg);
 }
 
 .target a:hover,
 .target a:active {
   transition: all 100ms ease-in-out;
-  color: var(--primaryDark);
+  color: var(--color-accent-dark-fg);
 }
 
 .target button {
@@ -84,8 +82,8 @@ Buttons and Links
   appearance: none;
   cursor: pointer;
   outline: none;
-  color: var(--primary);
-  border: solid 1px var(--primary);
+  color: var(--color-accent-fg);
+  border: solid 1px var(--color-accent-fg);
   padding: 4px 10px;
   border-radius: 6px;
   font-size: inherit;
@@ -94,16 +92,16 @@ Buttons and Links
 }
 
 .target button:hover {
-  background: var(--primary);
+  background: var(--color-accent-fg);
   transition: all 100ms ease-in-out;
   color: #fff;
 }
 
 .target strong {
-  color: var(--accent);
+  color: var(--color-secondary-fg);
 }
 
 .target code {
   font-family: Courier;
-  color: var(--code);
+  color: var(--color-code-fg);
 }

--- a/__stories__/assets/variables.css
+++ b/__stories__/assets/variables.css
@@ -1,0 +1,15 @@
+:root {
+  --font-mono: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
+    Liberation Mono, monospace;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-size: 16px;
+  --code-font-size: 85%;
+  --color-canvas-subtle: #f6f8fa;
+  --color-border-muted: #d8dee4;
+  --color-default-fg: #24292f;
+  --color-code-fg: #24292f;
+  --color-accent-fg: #0969da;
+  --color-accent-dark-fg: #0661c8;
+  --color-secondary-fg: #fb7a7a;
+}

--- a/__stories__/components/Example.svelte
+++ b/__stories__/components/Example.svelte
@@ -14,8 +14,6 @@
 
   // Coerce children to an array
   const childrenArray = Array.isArray(children) ? children : [children]
-  // Reference the target element(s)
-  let targetElement
   // Reference to the container element
   let containerElement
   // Resizer observer
@@ -48,7 +46,7 @@
 
   // If supported, create a resize observer for the container element
   if (window.ResizeObserver !== undefined) {
-    resizeObserver = new ResizeObserver(debounce(handleResize, 350))
+    resizeObserver = new ResizeObserver(debounce(handleResize, 100))
   }
 
   // Support "types=none" as an alias for types=""
@@ -56,7 +54,7 @@
 
   onMount(() => {
     // Split the the target element(s) using the provided options
-    instance = SplitType.create(targetElement, options)
+    instance = SplitType.create('.target', options)
     resizeObserver.observe(containerElement)
     console.log(instance)
   })
@@ -68,6 +66,6 @@
 
 <div bind:this={containerElement} class={`container ${className || ''}`}>
   {#each childrenArray as childContent}
-    <div bind:this={targetElement} class="target">{@html childContent}</div>
+    <div class="target">{@html childContent}</div>
   {/each}
 </div>

--- a/__stories__/docs/01-intro.stories.mdx
+++ b/__stories__/docs/01-intro.stories.mdx
@@ -1,0 +1,25 @@
+import { Meta } from '@storybook/addon-docs'
+
+<Meta title="Welcome" />
+
+# SplitType
+
+[![npm version](https://badge.fury.io/js/split-type.svg)](https://www.npmjs.com/package/split-type)
+
+SplitType is a small javascript library that splits HTML text into elements so that lines, words, and characters can be animated independently. It was inspired by GSAP's SplitText plugin, and can be used with any animation library.
+
+Under the hood, SplitType changes the html structure of the target elements, wrapping each line, word, and/or character in a element.
+
+## Features
+
+- Splits text into lines, words, and/or characters
+- Customizable class names for split text elements
+- Detects natural lines breaks in the text
+- Preserves explicit lines breaks (`<br>` tags)
+- Preserves nested HTML elements inside the target elements
+- Supports unicode symbols such as emojis
+
+## Docs
+
+- [Getting Started](?path=/story/getting-started--page)
+- [API Reference](?path=/story/api-reference--page)

--- a/__stories__/docs/02-getting-started.stories.mdx
+++ b/__stories__/docs/02-getting-started.stories.mdx
@@ -1,0 +1,173 @@
+import { Meta } from '@storybook/addon-docs'
+
+<Meta title="Getting Started" />
+
+# Getting Started
+
+## Installation
+
+```SHELL
+npm install 'split-type'
+```
+
+```js
+import SplitType from 'split-type'
+```
+
+Or, include the following `<script>` tag to load SplitType from a CDN. In this case, the `SplitType` class will be attached to `window` object.
+
+```html
+<!-- Minified UMD bundle -->
+<script src="https://unpkg.com/split-type"></script>
+```
+
+## Usage
+
+The SplitType class "splits" the text content of the target elements using the provided options. It returns a `SplitType` instance which provides access to the split text nodes.
+
+```js
+const text = new SplitType('#target')
+```
+
+You can also use the static method `SplitType.create`, which allows you to create a splitType instance without using the `new` keyword.
+
+```js
+// Creates a new SplitType instance
+const text = SplitType.create('.target')
+```
+
+### Types
+
+The `types` option lets you specify which units the text will be broken up into. There are three types: lines, words, and characters. You can specify any combination of these types.
+
+For multi-line text, you need to include words and/or lines in the list of types. Splitting text into characters only will result in unexpecpted line breaks.
+
+```js
+// Splits text into lines, words, characters (default)
+const text = new SplitType('#target')
+// Splits text into words and characters
+const text = new SplitType('#target', { types: 'words, chars' })
+// Splits text into lines
+const text = new SplitType('#target', { types: 'words' }
+```
+
+### Accessing split text nodes
+
+You can access the split lines/words/characters via properties on the `SplitType` instance.
+
+```js
+// Splits text in element with ID="target"
+const text = new SplitType('#target')
+
+// An array of the all line elements
+console.log(text.lines)
+// An array of all word elements
+console.log(text.words)
+// An array of all character elements
+console.log(text.chars)
+```
+
+Or using selectors
+
+```js
+const text = new SplitType('#target')
+const words = document.querySelectorAll('#target .word')
+```
+
+### Nested Elements
+
+As of `v0.3`, SplitType will preserve nested elements when the text is split. This makes it possible to:
+
+- Apply custom styles to specific parts of the test
+- Include interactive elements such links are buttons inside split text.
+
+```html
+<p id="target">Foo <em>Bar</em></p>
+```
+
+```js
+SplitType.create('#target')
+```
+
+Result
+
+```html
+<div class="target">
+  <div class="line" style="display: block; text-align: start; width: 100%">
+    <div class="word" style="display: inline-block; position: relative">
+      <div class="char" style="display: inline-block">F</div>
+      <div class="char" style="display: inline-block">o</div>
+      <div class="char" style="display: inline-block">o</div>
+    </div>
+    <em style="display: inline-block; position: relative"
+      ><div class="word" style="display: inline-block; position: relative">
+        <div class="char" style="display: inline-block">B</div>
+        <div class="char" style="display: inline-block">a</div>
+        <div class="char" style="display: inline-block">r</div>
+      </div>
+    </em>
+  </div>
+</div>
+```
+
+Caveat: this feature is not fully compatible with splitting text into lines. When split lines is enabled, if the text content of a nested element gets broken onto multiple lines, it will result in unexpected line breaks in the split text.
+
+You can use nested element when spliting text into lines, provided you can ensure that there will be no line breaks in the nested elements.
+
+### Absolute vs Relative position
+
+By default, split text nodes are set to relative position and `display:inline-block`. SplitType also supports absolute position for split text nodes by setting `{ absolute: true }`. When this is enabled, each line/word/character will be set to absolute position, which can improve performance for some animations.
+
+### Responsive Text
+
+When text is split into words and characters using relative position, the text will automatically reflow when the container is resized. However, when absolute position is enabled, or text is split into lines, the text will need to be re-split after the container is resized.
+
+This can be achieved by using an event listener or `ResizeObserver` to call the `split` method again after the window or container element has been resized.
+
+```js
+// This would be a reference to the container element that contains split text
+const containerElement
+// the SplitType instance
+const instance = new SplitType('#target')
+// stores the previous width of the container element
+let previousContainerWidth = null
+
+// An event handler that will be called when the container element is resized.
+function handleResize(entry) {
+  let width
+  // Only proceed if absolute position is enabled, or text is split into lines.
+  if (options.absolute || /lines/.test(String(options.types))) {
+    // The new width of the container element
+    const [{ contentRect }] = entry
+    width = Math.floor(contentRect.width)
+    // only proceed if:
+    // 1. previousContainerWidth has been set. This avoids calling the split
+    //    method when the resizeObserver is triggered on the initial render
+    // 2. the width of the container element has changed.
+    if (previousContainerWidth && previousContainerWidth !== width) {
+      // Call the split method to re-split the text. This will will reposition
+      // the text based on the new container size.
+      instance.split()
+    }
+  }
+  previousContainerWidth = width
+}
+
+// This example uses lodash#debounce so the split method only gets called once
+// after the resizing is complete.
+const resizeObserver = new ResizeObserver(debounce(handleResize, 500))
+resizeObserver.observe(containerElement)
+```
+
+```js
+// Split text into words and characters
+const text = new SplitType('#target', { types: 'words, chars' })
+
+// Animate characters into view with a stagger effect
+gsap.from(text.chars, {
+  opacity: 0,
+  y: 20,
+  duration: 0.5,
+  stagger: { amount: 0.1 },
+})
+```

--- a/__stories__/docs/03-api-reference.stories.mdx
+++ b/__stories__/docs/03-api-reference.stories.mdx
@@ -1,0 +1,68 @@
+import { Meta } from '@storybook/addon-docs'
+
+<Meta title="API Reference" />
+
+# API Reference
+
+```js
+new SplitType(target, [options])
+```
+
+The splitType class splits the text content of one or more elements and returns a new `SplitType` instance.
+
+#### target: &nbsp; `string | Element | NodeList | Element[]`
+
+Specifies the target elements for the SplitType call. This can be a selector string, a single `Element`, a collection of elements (such as a `NodeList`, jQuery Object, or `Array`).
+
+#### options: &nbsp; `SplitTypeOptions`
+
+| name       | type      | default                 | description                                                      |
+| ---------- | --------- | ----------------------- | ---------------------------------------------------------------- |
+| absolute   | `boolean` | `false`                 | If true, absolute position will be used to for split text nodes. |
+| tagName    | `string`  | `"div"`                 | The HTML tag that will be used for split text nodes              |
+| lineClass  | `string`  | `"line"`                | The className all split line elements                            |
+| wordClass  | `string`  | `"word"`                | The className for split word elements                            |
+| charClass  | `string`  | `"char"`                | The className for split character elements                       |
+| splitClass | `string`  | `null`                  | A className for all split text elements                          |
+| types      | `string`  | `"lines, words, chars"` | Comma separated list of types                                    |
+| split      | `string`  | `""`                    | Alias for `types`                                                |
+
+## Instance Properties
+
+#### `instance.lines`&nbsp;:&nbsp; `HTMLElement[]`
+
+An array of all split line elements in the splitType instance. If there are multiple target elements, this will include split lines from all elements.
+
+#### `instance.words`&nbsp;:&nbsp;`HTMLElement[]`
+
+An array of the split word elements in the splitType instance. If there are multiple target elements, this will include split words from all elements.
+
+#### `instance.chars`&nbsp;:&nbsp;`HTMLElement[]`
+
+An array of the split character elements. If there are multiple target elements, this will include split chars from all elements.
+
+#### `instance.split(options) => void`
+
+This method is automatically called by the SplitType constructor. But it can be called manually to re-split text using different options.
+
+#### `instance.revert() => void`
+
+Restores the target elements associated with this SplitType instance to their original text content. It also clears cached data associated with the split text nodes.
+
+## Static Properties
+
+#### `SplitType.defaults`&nbsp;:&nbsp;`SplitTypeOptions`
+
+Gets the current default settings for all SplitType instances. The default settings can be modified using the `setDefaults` methods.
+
+#### `SplitType.setDefaults(options: any) => SplitTypeOptions`
+
+Sets the default options for all `SplitType` instances. The provided object will be merged with the existing `SplitType.defaults` object. Returns the new defaults object.
+
+#### `SplitType.create(target, options) => SplitType`
+
+Creates a new `SplitType` instance using the provided parameters. This method can be used to call SplitType without using the `new` keyword. Returns the SplitType instance
+
+#### `SplitType.revert(target)`
+
+Reverts the target element(s) if they are currently split. This provides a way to revert split text without a reference to the `SplitType` instance.

--- a/lib/split.js
+++ b/lib/split.js
@@ -7,45 +7,47 @@ import { Data } from './Data'
  * The function is recursive, it will also split the text content of any child
  * elements into words/characters, while preserving the nested elements.
  *
- * @param {Node} element an HTML Element or Text Node
+ * @param {Node} node an HTML Element or Text Node
  * @param {Object} setting splitType settings
  */
-export default function split(element, settings) {
-  // A) If `element` is a text node...
-  //    Split the text content of the node into words and/or characters
-  //    returns an object containing the split word and characters
-  if (element.nodeType === 3) {
-    return splitWordsAndChars(element, settings)
+export default function split(node, settings) {
+  const type = node.nodeType
+  // Arrays of split words and characters
+  const wordsAndChars = { words: [], chars: [] }
+
+  // IF `node` is a text node that contains characters other than white space...
+  // Split the text content of the node into words and/or characters
+  // returns an object containing the split word and characters
+  if (type === 3 && /[^\n\s]/.test(String(node.nodeValue))) {
+    return splitWordsAndChars(node, settings)
   }
 
-  // B) if not, element is an HTML element or fragment
-  //    We will iterate through the child nodes of the element,
-  //    calling the `split` function recursively for each child.
-  const childNodes = toArray(element.childNodes)
+  // if not, element is an HTML element or fragment
+  // We will iterate through the child nodes of the element,
+  // calling the `split` function recursively for each child.
+  const childNodes = toArray(node.childNodes)
 
   if (childNodes.length) {
-    Data(element).isSplit = true
+    Data(node).isSplit = true
     // we need to set a few styles on nested html elements
-    if (!Data(element).isRoot) {
-      element.style.display = 'inline-block'
-      element.style.position = 'relative'
+    if (!Data(node).isRoot) {
+      node.style.display = 'inline-block'
+      node.style.position = 'relative'
       // To maintain original spacing around nested elements when we are
       // splitting text into lines, we need to check if the element should
       // have a space before and after, and store that value for later.
       // Note: this was necessary to maintain the correct spacing when nested
       // elements do not align with word boundaries. For example, a nested
       // element only wraps part of a word.
-      const nextSibling = element.nextSibling
-      const prevSibling = element.previousSibling
-      const text = element.textContent || ''
+      const nextSibling = node.nextSibling
+      const prevSibling = node.previousSibling
+      const text = node.textContent || ''
       const textAfter = nextSibling ? nextSibling.textContent : ' '
       const textBefore = prevSibling ? prevSibling.textContent : ' '
-      Data(element).isWordEnd = /\s$/.test(text) || /^\s/.test(textAfter)
-      Data(element).isWordStart = /^\s/.test(text) || /\s$/.test(textBefore)
+      Data(node).isWordEnd = /\s$/.test(text) || /^\s/.test(textAfter)
+      Data(node).isWordStart = /^\s/.test(text) || /\s$/.test(textBefore)
     }
   }
-
-  const wordsAndChars = { words: [], chars: [] }
 
   // Iterate through child nodes, calling `split` recursively
   // Returns an object containing all split words and chars

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "husky": "^7.0.0",
     "jest": "27.x",
     "jest-transform-svelte": "^2.1.1",
+    "jest-transformer-mdx": "^3.3.0",
     "lodash": "^4.17.21",
     "onchange": "^7.1.0",
     "prettier": "^2.6.2",
@@ -79,7 +80,8 @@
   "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
-      "^.+\\.svelte$": "jest-transform-svelte"
+      "^.+\\.svelte$": "jest-transform-svelte",
+      "^.+\\.mdx?$": "@storybook/addon-docs/jest-transform-mdx"
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(@storybook/svelte)/)"


### PR DESCRIPTION
Fix: Splitting text does not work as expected when target elements contain comment nodes.  This resulted in empty word and line elements in the split text, and unexpected white space (caused by empty word elements). 

Changes: 

- ignore text nodes that contain only white space. The split function already ignores comment nodes. But the white space around comment nodes was causing issues. 
- Add new example and tests with target elements containing comment nodes. 
