### PR TITLE
fix: issue 45

### DIFF
--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -205,5 +205,3 @@ export default class SplitType {
     SplitType.revert(this.elements)
   }
 }
-
-window.SplitType = SplitType

--- a/lib/utils/polyfill.js
+++ b/lib/utils/polyfill.js
@@ -1,5 +1,5 @@
-// Polyfill for the following DOM methods which are not supported in IE 11
-// We will be dropping support for IE in an upcoming version
+// Polyfill the following DOM methods that are not supported in IE 11.
+// This can be removed in the near future since we no longer support IE.
 // - Element.append
 // - Element.replaceWith
 // - Element.replaceChildren
@@ -39,17 +39,18 @@
       }
     }
   }
-
-  if (!Element.prototype.append) {
-    Element.prototype.append = append
-    DocumentFragment.prototype.append = append
-  }
-  if (!Element.prototype.replaceChildren) {
-    Element.prototype.replaceChildren = replaceChildren
-    DocumentFragment.prototype.replaceChildren = replaceChildren
-  }
-  if (!Element.prototype.replaceWith) {
-    Element.prototype.replaceWith = replaceWith
-    DocumentFragment.prototype.replaceWith = replaceWith
+  if (typeof Element !== 'undefined') {
+    if (!Element.prototype.append) {
+      Element.prototype.append = append
+      DocumentFragment.prototype.append = append
+    }
+    if (!Element.prototype.replaceChildren) {
+      Element.prototype.replaceChildren = replaceChildren
+      DocumentFragment.prototype.replaceChildren = replaceChildren
+    }
+    if (!Element.prototype.replaceWith) {
+      Element.prototype.replaceWith = replaceWith
+      DocumentFragment.prototype.replaceWith = replaceWith
+    }
   }
 })()


### PR DESCRIPTION
Fixes error when importing SplitType isomorphic applications such as NextJS.  The error was caused by a reference to `Element` which is not defined in node. 

```
ReferenceError: Element is not defined
```


For #45 