### PR TITLE
Fix issue 47

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-npx pretty-quick --staged
+# npx pretty-quick --staged

--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -116,14 +116,6 @@ export default class SplitType {
     this.isSplit = false
     this.settings = extend(_defaults, parseSettings(options))
     this.elements = getTargetElements(elements)
-    // Revert target elements (if they are already split)
-    // Note: we need to call `revert` in the constructor before caching the
-    // original html content of the target elements.
-    this.revert()
-    // Store the original html content of each target element
-    this.elements.forEach((element) => {
-      data.set(element, 'html', element.innerHTML)
-    })
     // Start the split process
     this.split()
   }
@@ -141,6 +133,11 @@ export default class SplitType {
     // need to call it again here so text is reverted when the user manually
     // calls the `split` method to re-split text.
     this.revert()
+
+    // Store the original html content of each target element
+    this.elements.forEach((element) => {
+      data.set(element, 'html', element.innerHTML)
+    })
 
     // Create arrays to hold the split lines, words, and characters
     this.lines = []


### PR DESCRIPTION
Issue: calling the `split` method multiple times on an instance causes the html content to be replaced with "undefined" (see #47)
 

Fix, store the original html content of the target elements at the beginning of the split method, instead of in the constructor.

#closes #47
