### PR TITLE
added closing paren in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const text = new SplitType('#target')
 // Splits text into words and characters
 const text = new SplitType('#target', { types: 'words, chars' })
 // Splits text into lines
-const text = new SplitType('#target', { types: 'words' }
+const text = new SplitType('#target', { types: 'words' })
 ```
 
 ### Accessing split text nodes


### PR DESCRIPTION
Just a little typo in the docs. Thanks so much for this library I use it in a ton of my coding videos.