### PR TITLE
Add index CSS variables to lines, words and chars

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -6,4 +6,5 @@ export default {
   types: ['lines', 'words', 'chars'],
   absolute: false,
   tagName: 'div',
+  addIndex: true,
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,6 +14,7 @@ declare module 'split-type' {
     splitClass: string
     types: TypesListString | TypesValue[]
     split: TypesListString | TypesValue[]
+    addIndex: boolean
   }
 
   type TargetElement =

--- a/lib/repositionAfterSplit.js
+++ b/lib/repositionAfterSplit.js
@@ -121,9 +121,10 @@ export default function repositionAfterSplit(element, settings, scrollPos) {
     // Return an array of the wrapped line elements (lineElements)
     lines = wordsInEachLine.map((wordsInThisLine, idx) => {
       // Create an element to wrap the current line.
+      const lineIndex = settings.addIndex ? `--index-line: ${idx};` : ''
       const lineElement = createElement(TAG_NAME, {
         class: `${settings.splitClass} ${settings.lineClass}`,
-        style: `--index-line: ${idx}; display: block; text-align: ${align}; width: 100%;`,
+        style: `${lineIndex} display: block; text-align: ${align}; width: 100%;`,
       })
       data.set(lineElement, 'isLine', true)
 

--- a/lib/repositionAfterSplit.js
+++ b/lib/repositionAfterSplit.js
@@ -119,11 +119,11 @@ export default function repositionAfterSplit(element, settings, scrollPos) {
     // Iterate over lines of text (see 11 b)
     // Let `line` be the array of words in the current line.
     // Return an array of the wrapped line elements (lineElements)
-    lines = wordsInEachLine.map((wordsInThisLine) => {
+    lines = wordsInEachLine.map((wordsInThisLine, idx) => {
       // Create an element to wrap the current line.
       const lineElement = createElement(TAG_NAME, {
         class: `${settings.splitClass} ${settings.lineClass}`,
-        style: `display: block; text-align: ${align}; width: 100%;`,
+        style: `--index-line: ${idx}; display: block; text-align: ${align}; width: 100%;`,
       })
       data.set(lineElement, 'isLine', true)
 

--- a/lib/splitWordsAndChars.js
+++ b/lib/splitWordsAndChars.js
@@ -45,10 +45,10 @@ export default function splitWordsAndChars(textNode, settings) {
     // -> If splitting text into characters...
     if (types.chars) {
       // Iterate through the characters in the current word
-      characterElementsForCurrentWord = toChars(WORD).map((CHAR) => {
+      characterElementsForCurrentWord = toChars(WORD).map((CHAR, idxChar) => {
         const characterElement = createElement(TAG_NAME, {
           class: `${settings.splitClass} ${settings.charClass}`,
-          style: 'display: inline-block;',
+          style: `--index-char: ${idxChar}; display: inline-block;`,
           children: CHAR,
         })
         data.set(characterElement, 'isChar', true)
@@ -65,7 +65,7 @@ export default function splitWordsAndChars(textNode, settings) {
       //    plain text content (WORD)
       wordElement = createElement(TAG_NAME, {
         class: `${settings.wordClass} ${settings.splitClass}`,
-        style: `display: inline-block; ${
+        style: `--index-word: ${idx}; display: inline-block; ${
           types.words && settings.absolute ? `position: relative;` : ''
         }`,
         children: types.chars ? characterElementsForCurrentWord : WORD,

--- a/lib/splitWordsAndChars.js
+++ b/lib/splitWordsAndChars.js
@@ -46,9 +46,10 @@ export default function splitWordsAndChars(textNode, settings) {
     if (types.chars) {
       // Iterate through the characters in the current word
       characterElementsForCurrentWord = toChars(WORD).map((CHAR, idxChar) => {
+        const charIndex = settings.addIndex ? `--index-char: ${idxChar};` : ''
         const characterElement = createElement(TAG_NAME, {
           class: `${settings.splitClass} ${settings.charClass}`,
-          style: `--index-char: ${idxChar}; display: inline-block;`,
+          style: `${charIndex} display: inline-block;`,
           children: CHAR,
         })
         data.set(characterElement, 'isChar', true)
@@ -63,9 +64,10 @@ export default function splitWordsAndChars(textNode, settings) {
       //    splitting text into characters, the word element will contain the
       //    wrapped character nodes for this word. If not, it will contain the
       //    plain text content (WORD)
+      const wordIndex = settings.addIndex ? `--index-word: ${idx};` : ''
       wordElement = createElement(TAG_NAME, {
         class: `${settings.wordClass} ${settings.splitClass}`,
-        style: `--index-word: ${idx}; display: inline-block; ${
+        style: `${wordIndex} display: inline-block; ${
           types.words && settings.absolute ? `position: relative;` : ''
         }`,
         children: types.chars ? characterElementsForCurrentWord : WORD,


### PR DESCRIPTION
Regarding [our discussion](https://github.com/lukePeavey/SplitType/issues/57) @lukePeavey, I gave it a go and implemented this feature as it seemed to be fairly simple for me to try 😄

It works pretty well imo but let me know if things need changes! I also added a setting (true by default, can be put back to false, up to you) to control this behavior

![image](https://user-images.githubusercontent.com/273716/218720325-2595e7d7-0235-4781-be3f-91476cf1c6d8.png)