### PR TITLE
Add even BETTER typing for `type` and `split` options

### DIFF
--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -145,7 +145,7 @@ export default class SplitType {
     this.chars = []
 
     // cache vertical scroll position before splitting
-    const scrollPos = [window.scrollX, window.scrollY]
+    const scrollPos = [window.pageXOffset, window.pageYOffset]
 
     // If new options were passed into the `split()` method, update settings
     if (options !== undefined) {

--- a/lib/SplitType.js
+++ b/lib/SplitType.js
@@ -145,7 +145,7 @@ export default class SplitType {
     this.chars = []
 
     // cache vertical scroll position before splitting
-    const scrollPos = [window.pageXOffset, window.pageYOffset]
+    const scrollPos = [window.scrollX, window.scrollY]
 
     // If new options were passed into the `split()` method, update settings
     if (options !== undefined) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -25,8 +25,6 @@ declare module 'split-type' {
     split: TypesList
   }
 
-  let splitTypeOptions: SplitTypeOptions
-
   type TargetElement =
     | string
     | HTMLElement

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,30 +1,4 @@
 declare module 'split-type' {
-  /**
-   * UnionToIntersection<{ foo: string } | { bar: string }> =
-   *  { foo: string } & { bar: string }.
-   */
-  type UnionToIntersection<U> = (
-    U extends unknown ? (arg: U) => 0 : never
-  ) extends (arg: infer I) => 0
-    ? I
-    : never
-
-  /**
-   * LastInUnion<1 | 2> = 2.
-   */
-  type LastInUnion<U> = UnionToIntersection<
-    U extends unknown ? (x: U) => 0 : never
-  > extends (x: infer L) => 0
-    ? L
-    : never
-
-  /**
-   * UnionToTuple<1 | 2> = [1, 2].
-   */
-  type UnionToTuple<U, Last = LastInUnion<U>> = [U] extends [never]
-    ? []
-    : [...UnionToTuple<Exclude<U, Last>>, Last]
-
   type StringedCombination<
     T extends string[],
     Sep extends string = ' ',
@@ -34,21 +8,11 @@ declare module 'split-type' {
     ? Item | `${Item}${Sep}${StringedCombination<[], Sep, Exclude<All, Item>>}`
     : never
 
-  type TupledCombination<
-    T extends string[],
-    All = T[number],
-    Item = All,
-  > = Item extends string
-    ? [Item] | [Item, ...TupledCombination<[], Exclude<All, Item>>]
-    : never
+  type TypesValue = ['lines', 'words', 'chars']
 
-  type TypesValue = 'lines' | 'words' | 'chars'
-  type TupleTypesValue = UnionToTuple<TypesValue>
+  type TypesListString = StringedCombination<TypesValue, ','>
 
-  type TypesListString = StringedCombination<TupleTypesValue, ','>
-  type TypesListTuple = TupledCombination<TupleTypesValue>
-
-  type TypesList = TypesListString | TypesValue[]
+  type TypesList = TypesListString | TypesValue[number][]
 
   type SplitTypeOptions = {
     absolute: boolean


### PR DESCRIPTION
Right now, we have a naive combination for the three splitting options which makes it quite difficult to see what you want (repetitions, mainly). Adding a custom type to create true combinations to keep the suggestions nice, accurate and concise.

**Before:**
<img width="338" alt="Screenshot 2023-08-13 at 9 44 45 PM" src="https://github.com/lukePeavey/SplitType/assets/33600496/2d162dde-489a-4598-ac3a-aa05dc8c2e92">

**After:**
<img width="338" alt="Screenshot 2023-08-13 at 9 43 06 PM" src="https://github.com/lukePeavey/SplitType/assets/33600496/a87ac483-fe23-431c-8b37-aadc58691530">

I also experimented with tuple combinations, but TypeScript seems to flatten it down to just array element suggestions and stops suggesting combos after the third element. But it doesn't stop you from defining a fourth element, which is not what you want.

Another thing to note, I've changed `TypesValue` from being a union to a tuple, just to keep the typing as simple as possible. The first commit actually has a version where it converts the union to a tuple to do the combination, but it seemed unnecessary and too much for something simple, so I changed it instead.

## Suggestion: 
Maybe to make it stricter and allow JS interop, we can create an object that stores the values of the different combos.

```ts
SplitType.TypeOptions = {
  Lines: 'lines',
  Words: 'words',
  Chars: 'chars',
  LinesWords: 'lines,words',
  WordsChars: 'words,chars',
  LinesChars: 'lines,chars'
}

new SplitType({..., type: SplitType.TypeOptions.LinesChars})
```

This would limit the number of user errors if you limit them to only these options.